### PR TITLE
fix(preprocess): Directory separators on Windows

### DIFF
--- a/packages/lib/src/svelte-ts-preprocess.ts
+++ b/packages/lib/src/svelte-ts-preprocess.ts
@@ -157,6 +157,8 @@ export function preprocess(opts?: Partial<PreprocessOptions>) {
       return
     }
 
+    filename = ts.sys.resolvePath(filename)
+
     const options = createPreprocessOptions(opts)
 
     const rootFiles = [filename]


### PR DESCRIPTION
See https://github.com/pyoner/svelte-ts-template/issues/3