### PR TITLE
Preserve all typescript imports, not only .svelte

### DIFF
--- a/packages/lib/src/svelte-ts-preprocess.ts
+++ b/packages/lib/src/svelte-ts-preprocess.ts
@@ -6,17 +6,12 @@ function importTransformer<T extends ts.Node>(): ts.TransformerFactory<T> {
   return context => {
     const visit: ts.Visitor = node => {
       if (ts.isImportDeclaration(node)) {
-        const text = node.moduleSpecifier.getText().slice(0, -1)
-        if (text.endsWith('.svelte')) {
-          // console.log('------- svelte import -----')
-          // console.log(node.getFullText().trim())
-          return ts.createImportDeclaration(
-            node.decorators,
-            node.modifiers,
-            node.importClause,
-            node.moduleSpecifier
-          )
-        }
+        return ts.createImportDeclaration(
+          node.decorators,
+          node.modifiers,
+          node.importClause,
+          node.moduleSpecifier
+        )
       }
       return ts.visitEachChild(node, child => visit(child), context)
     }


### PR DESCRIPTION
Hi! Thanks for the project. Library already preserves all `.svelte` imports. This PR change behaviour to preserve _all_ imports, because imported variables can be not only svelte components but also values which svelte template actually uses. Example:

```
<script lang="ts">
  import { writable } from "svelte/store";
  import { count } from "./stores";
  import Counter from "./Counter.svelte";

  export let name: number;
  export let age: number;
</script>

<h1>Hello {name} ({age})!</h1>
<p>
  <Counter />
  <Counter value={1}>Counter 1</Counter>
  <Counter value={$count} step={3}>Counter 2</Counter>
</p>
```

Without the fix compiler throws:

```
(!) svelte plugin: 'count' is not defined
src/App.svelte
   <Counter />
  <Counter value={1}>Counter 1</Counter>   
  <Counter value={$count} step={3}>Counter 2</Counter>
                  ^
</p>
```

Relates to:
- https://github.com/PaulMaly/svelte-ts-preprocess/issues/4 
- https://github.com/microsoft/TypeScript/issues/9191